### PR TITLE
Enable dependabot for cnab-go

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    allow:
+      - dependency-name: github.com/cnabio/cnab-go


### PR DESCRIPTION
Let's try out using dependabot on our project and start with just cnab-go.
I don't want to be overwhelmed with a bunch of updated deps and would like
to see first what it does with our biggest dependency.
